### PR TITLE
Nicer CUDA error messages

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -6,7 +6,7 @@ cradle:
     - path: "solid/test/tasty"
       component: "solid:test:tasty"
 
-    - path: "solid-cuda/solid-cuda/src"
+    - path: "solid-cuda/src"
       component: "lib:solid-cuda"
 
     - path: "solid-cuda/solid-cuda/test/tasty"

--- a/solid-cuda/src/Data/Solid/Cuda/Internal.hs
+++ b/solid-cuda/src/Data/Solid/Cuda/Internal.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Data.Solid.Cuda.Internal
   ( CudaT,
@@ -8,6 +10,8 @@ module Data.Solid.Cuda.Internal
     callCuda,
     CudaException (..),
     throwErrorCuda,
+    getErrorName,
+    getErrorString,
   )
 where
 
@@ -22,6 +26,13 @@ import Control.Monad.Trans.Writer
 import Data.Solid.Shape
 import Foreign.C.Types (CInt)
 import GHC.Stack (HasCallStack, callStack, prettyCallStack, withFrozenCallStack)
+import GHC.IO (unsafePerformIO)
+import Foreign.C.String (peekCString, CString)
+import qualified Language.C.Inline as C
+
+C.context C.baseCtx
+C.include "<cuda.h>"
+C.include "<cuda_runtime.h>"
 
 newtype CudaT m a = CudaT {unCudaT :: ExceptT CudaException m a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadError CudaException, MonadThrow, MonadCatch, MonadMask)
@@ -63,7 +74,12 @@ data CudaException
   | InvalidShape String Dims
 
 instance Show CudaException where
-  show (CudaError stack errno) = "CUDA error with code " <> show errno <> ", " <> stack
+  show (CudaError stack errno) =
+    "CUDA error code " <>
+    show errno <> " " <>
+    unsafePerformIO (peekCString =<< getErrorName (fromIntegral errno)) <> ",\n" <>
+    unsafePerformIO (peekCString =<< getErrorString (fromIntegral errno)) <> "\n" <>
+    stack
   show (ContextTooSmall stack) = "Insufficient capacity " <> stack
   show AllocationFailed = "CUDA failed to allocate required memory"
   show (InvalidShape reason dims) = "Invalid shape " <> reason <> ", but got: " <> show dims
@@ -90,3 +106,15 @@ callCuda code =
           if c == 10001
             then ContextTooSmall (prettyCallStack callStack)
             else CudaError (prettyCallStack callStack) (fromIntegral c)
+
+-- | @\__host\__\​__device\__​const char* cudaGetErrorName ( cudaError_t error )@
+--
+-- https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__ERROR.html#group__CUDART__ERROR_1gb3de7da2f23736878270026dcfc70075
+getErrorName :: CInt -> IO CString
+getErrorName cudaError = [C.exp| const char* { cudaGetErrorName ( $(int cudaError) ) } |]
+
+-- | @\__host\__\​__device\__​const char* cudaGetErrorString ( cudaError_t error )@
+--
+-- https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__ERROR.html#group__CUDART__ERROR_1g4bc9e35a618dfd0877c29c8ee45148f1
+getErrorString :: CInt -> IO CString
+getErrorString cudaError = [C.exp| const char* { cudaGetErrorString ( $(int cudaError) ) } |]


### PR DESCRIPTION
Resolves #4 

Old:

```
      Unexpected exception when running CUDA: CUDA error with code 35, CallStack (from HasCallStack)
```

New:

```
      Unexpected exception when running CUDA: CUDA error code 35 cudaErrorInsufficientDriver,
      CUDA driver version is insufficient for CUDA runtime version
      CallStack (from HasCallStack):
```